### PR TITLE
Adjusted Docker behavior

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN useradd appuser && chown -R appuser /app
 USER appuser
 
 # During debugging, this entry point will be overridden. For more information, please refer to https://aka.ms/vscode-docker-python-debug
-CMD ["python", "src/main.py"]
+CMD ["python", "src/dockermain.py"]

--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,13 @@
 # build and run the docker container
 # Kai Brooks
 # github.com/kaibrooks
-#
+
 chmod +x build.sh # give execution privs to this script
 docker build -t capstone-colander . # build it
 
+# remove the old container
+# this stops the container from continuing in the background if re-run
+docker stop cc
+
 # docker run -it --entrypoint sh capstone-colander:latest   # build to explore the container
-docker run -it --rm -v `pwd`/io:/io capstone-colander:latest # gotta bind io if we want to output data
+docker run -it --name cc --rm -v `pwd`/io:/io capstone-colander:latest # gotta bind io if we want to output data

--- a/dockerdelete.sh
+++ b/dockerdelete.sh
@@ -1,0 +1,6 @@
+# Delete every Docker containers
+# Must be run first because images are attached to containers
+docker rm -f $(docker ps -a -q)
+
+# Delete every Docker image
+docker rmi -f $(docker images -q)

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,12 @@
 # just run the docker container
 # Kai Brooks
 # github.com/kaibrooks
-#
-chmod +x run.sh
-docker run -it --rm capstone-colander:latest
+
+chmod +x run.sh # give execution privs to this script
+
+# remove the old container
+# this stops the container from continuing in the background if re-run
+docker stop cc
+
+# docker run -it --entrypoint sh capstone-colander:latest   # build to explore the container
+docker run -it --name cc --rm -v `pwd`/io:/io capstone-colander:latest # gotta bind io if we want to output data

--- a/src/dockermain.py
+++ b/src/dockermain.py
@@ -1,0 +1,14 @@
+# this is a "staging" file, it just calls another file
+# it's here because docker always runs "dockermain.py"
+# change the actual file to run on the last line
+# don't develop in this
+
+import os
+from datetime import date, datetime
+
+# startup information
+now = datetime.today().strftime('%Y-%m-%d %H:%M:%S') # get the date/time
+print("Container built", now) # print it
+
+# call another script
+os.system('python src/main.py') # put what file we actually want run here


### PR DESCRIPTION
Docker runs dockermain.py instead of main.py -- this is so automated tests through Docker can invoke main with arguments via scripting to emulate the CLI

Changed build behavior to name and stop containers, so containers won't run multiple times in the background if developers re-run them before completing the first run

Added a shell script to wipe all docker containers and images